### PR TITLE
Update exception patch

### DIFF
--- a/master_info/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/master_info/MasterInfo.java
+++ b/master_info/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/master_info/MasterInfo.java
@@ -9,6 +9,7 @@ import com.github.robotics_in_concert.rocon_rosjava_core.rosjava_utils.ListenerN
 import com.github.robotics_in_concert.rocon_rosjava_core.rosjava_utils.RosTopicInfo;
 import com.google.common.collect.Lists;
 
+import org.ros.exception.RosRuntimeException;
 import org.ros.internal.loader.CommandLineLoader;
 import org.ros.namespace.GraphName;
 import org.ros.node.AbstractNodeMain;
@@ -31,13 +32,21 @@ public class MasterInfo extends AbstractNodeMain {
 		this.masterInfoListener = new ListenerNode<rocon_std_msgs.MasterInfo>();
 	}
     @Override
-    public void onStart(final ConnectedNode connectedNode) {
-        RosTopicInfo topicInformation = new RosTopicInfo(connectedNode);
-    	String topicName = topicInformation.findTopic("rocon_std_msgs/MasterInfo");
-    	this.masterInfoListener.connect(connectedNode, topicName, rocon_std_msgs.MasterInfo._TYPE);
-    }
+	public void onStart (final ConnectedNode connectedNode) {
+		try{
+			RosTopicInfo topicInformation = new RosTopicInfo(connectedNode);
+			String topicName = topicInformation.findTopic("rocon_std_msgs/MasterInfo");
+			this.masterInfoListener.connect(connectedNode, topicName, rocon_std_msgs.MasterInfo._TYPE);
+		} catch (RosRuntimeException e){
+			try {
+				throw new MasterInfoException(e.getMessage());
+			} catch (MasterInfoException e1) {
+				e1.printStackTrace();
+			}
+		}
+	}
 
-    /**
+	/**
      * Wait for data to come in. This uses a default timeout
      * set by ListenerNode.
      * 

--- a/rocon_interactions/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rocon_interactions/RoconInteractions.java
+++ b/rocon_interactions/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rocon_interactions/RoconInteractions.java
@@ -78,8 +78,21 @@ public class RoconInteractions extends AbstractNodeMain {
     		}
     	} catch (ServiceNotFoundException e) {
     		// should be having some sort of error flag that can be picked up in waitForResponse
-        	return;
+			try {
+				throw new ServiceNotFoundException(e.getMessage());
+			} catch (ServiceNotFoundException e1) {
+				e1.printStackTrace();
+			}
     	}
+		catch (RosRuntimeException e) {
+			// should be having some sort of error flag that can be picked up in waitForResponse
+			try {
+				throw new RosRuntimeException (e.getMessage());
+			} catch (RosRuntimeException e1) {
+				e1.printStackTrace();
+			}
+			return;
+		}
     }
 
     /**

--- a/rosjava_utils/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rosjava_utils/BlockingServiceClientNode.java
+++ b/rosjava_utils/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rosjava_utils/BlockingServiceClientNode.java
@@ -5,6 +5,7 @@ package com.github.robotics_in_concert.rocon_rosjava_core.rosjava_utils;
 *****************************************************************************/
 
 import org.ros.exception.RemoteException;
+import org.ros.exception.RosRuntimeException;
 import org.ros.exception.ServiceNotFoundException;
 import org.ros.namespace.NameResolver;
 import org.ros.namespace.NodeNameResolver;
@@ -35,6 +36,9 @@ public class BlockingServiceClientNode<RequestType, ResponseType> {
         } catch (ServiceNotFoundException e) {
         	throw e;
         }
+		catch (RosRuntimeException e) {
+			throw e;
+		}
 		srvClient.call(request, this.setupListener());
 	}
 

--- a/rosjava_utils/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rosjava_utils/BlockingServiceClientNode.java
+++ b/rosjava_utils/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rosjava_utils/BlockingServiceClientNode.java
@@ -35,11 +35,10 @@ public class BlockingServiceClientNode<RequestType, ResponseType> {
         	srvClient = connectedNode.newServiceClient(resolvedServiceName, serviceType);
         } catch (ServiceNotFoundException e) {
         	throw e;
-        }
-		catch (RosRuntimeException e) {
-			throw e;
-		}
-		srvClient.call(request, this.setupListener());
+        } catch (RosRuntimeException e) {
+          throw e;
+	   }
+	   srvClient.call(request, this.setupListener());
 	}
 
 	public void waitForResponse() {

--- a/rosjava_utils/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rosjava_utils/ListenerNode.java
+++ b/rosjava_utils/src/main/java/com/github/robotics_in_concert/rocon_rosjava_core/rosjava_utils/ListenerNode.java
@@ -63,7 +63,7 @@ public class ListenerNode<MsgType> {
                 throw new ListenerException(e);
             }
             // timeout.
-            if ( count == 20 ) {
+            if ( count == 50 ) {
                 this.errorMessage = "timed out waiting for a " + subscriber.getTopicName() + "publication";
                 throw new TimeoutException(this.errorMessage);
             }


### PR DESCRIPTION
- Add exception handler for `RosRuntimeException`
- Including PR 7
  -  Increase timeout in listener proxy
    In case of using low spec device (ex. nexus 10/ Lollipop), Concert checker occasionally returned `MasterInfo` message does not receive error. Because low spec device is not enough 4s for receiving message.
  -  Addition of Exception handling in onStart function of MasterInfo class.
    The android app using MasterInfo class for checking concert is died if it run in only launched roscore.
